### PR TITLE
Implemented NodeAPI deploy method

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbt._
+
 name := "edi2rho"
 
 version := "0.1"
@@ -7,10 +9,17 @@ scalaVersion := "2.13.8"
 val catsVersion = "2.7.0"
 val catsEffectVersion = "3.3.11"
 
+Compile / PB.targets := Seq(
+  scalapb.gen() -> (Compile / sourceManaged).value / "scalapb"
+)
+
 libraryDependencies += ("org.typelevel" %% "cats-kernel" % catsVersion).withSources().withJavadoc()
 libraryDependencies += ("org.typelevel" %% "cats-core" % catsVersion).withSources().withJavadoc()
 libraryDependencies += ("org.typelevel" %% "cats-effect" % catsEffectVersion).withSources().withJavadoc()
 libraryDependencies += "dev.profunktor" %% "fs2-rabbit" % "5.0.0"
 libraryDependencies += "com.github.pureconfig" %% "pureconfig" % "0.17.1"
+libraryDependencies += "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"
+libraryDependencies += "io.grpc" % "grpc-netty" % scalapb.compiler.Version.grpcJavaVersion
+libraryDependencies += "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-language:postfixOps", "-language:higherKinds")

--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.1"

--- a/src/main/protobuf/DeployServiceV1.proto
+++ b/src/main/protobuf/DeployServiceV1.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+service DeployService {
+  // Queue deployment of Rholang code (or fail to parse).
+  rpc deploy(DeployDataProto) returns (DeployResponse) {}
+}
+
+message DeployDataProto {
+  bytes  deployer              = 1;   // public key
+  string term                  = 2;   // rholang source code to deploy (will be parsed into `Par`)
+  int64  timestamp             = 3;   // millisecond timestamp
+  bytes  sig                   = 4;   // signature of (hash(term) + timestamp) using private key
+  string sigAlgorithm          = 5;   // name of the algorithm used to sign
+  int64  phloPrice             = 7;   // phlo price
+  int64  phloLimit             = 8;   // phlo limit for the deployment
+  int64  validAfterBlockNumber = 10;
+  string shardId               = 11;  // shard ID to prevent replay of deploys between shards
+}
+
+message DeployResponse {
+  oneof message {
+    ServiceError error = 1;
+    string result      = 2;
+  }
+}
+
+message ServiceError {
+  repeated string messages = 1;
+}

--- a/src/main/scala/coop/rchain/edi2rho/NodeAPI.scala
+++ b/src/main/scala/coop/rchain/edi2rho/NodeAPI.scala
@@ -1,8 +1,27 @@
 package coop.rchain.edi2rho
 
+import DeployServiceV1.{DeployDataProto, DeployServiceGrpc}
 import cats.effect.Sync
+import cats.syntax.all._
 import coop.rchain.edi2rho.Parser.Parsed
+import io.grpc.ManagedChannelBuilder
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object NodeAPI {
-  def deploy[F[_]: Sync](payload: Parsed): F[Unit] = ???
+  def deploy[F[_]: Sync](payload: Parsed): F[Unit] = {
+    // TODO: Should be configurable.
+    val (host, port) = ("http://localhost/", 40401)
+    for {
+      channel <- Sync[F].delay(
+        ManagedChannelBuilder.forAddress(host, port).usePlaintext().asInstanceOf[ManagedChannelBuilder[_]].build
+      )
+      client = DeployServiceGrpc.stub(channel)
+      // TODO: You should not use a raw protobuf message. Deploy should be signed.
+      request = DeployDataProto(term = "Nil")
+      reply = client.deploy(request)
+    } yield reply.onComplete { answer =>
+      println(answer.map(_ => "Deploy completed successfully").getOrElse("Deploy execution error"))
+    }
+  }
 }


### PR DESCRIPTION
This pull request implements the `NodeAPI.deploy` method via the `gRPC` interface. The interface of the service and messages is fully consistent with those in the [RNode project](https://github.com/rchain/rchain). The service contains only one `deploy` method.

The RNode host and port are currently not configurable. Also, a "raw" protobuf message without signing is used as data to be sent over the gRPC interface. This can be implemented in the future pull requests.
